### PR TITLE
Remove unnecessary argument to subscription.Sub

### DIFF
--- a/relaypool.go
+++ b/relaypool.go
@@ -181,7 +181,7 @@ func (r *RelayPool) Sub(filters EventFilters) *Subscription {
 	random := make([]byte, 7)
 	rand.Read(random)
 
-	subscription := Subscription{}
+	subscription := Subscription{filters: filters}
 	subscription.channel = hex.EncodeToString(random)
 	subscription.relays = make(map[string]*websocket.Conn)
 	for relay, policy := range r.Relays {
@@ -194,7 +194,7 @@ func (r *RelayPool) Sub(filters EventFilters) *Subscription {
 	subscription.UniqueEvents = make(chan Event)
 	r.subscriptions[subscription.channel] = &subscription
 
-	subscription.Sub(filters)
+	subscription.Sub()
 	return &subscription
 }
 

--- a/subscription.go
+++ b/subscription.go
@@ -36,7 +36,7 @@ func (subscription Subscription) Unsub() {
 	}
 }
 
-func (subscription Subscription) Sub(filters EventFilters) {
+func (subscription Subscription) Sub() {
 	for _, ws := range subscription.relays {
 		message := []interface{}{
 			"REQ",


### PR DESCRIPTION
The `Sub()` function retrieves the list of filters from the
`Subscripton` object itself, and therefore it's unnecessary to pass it
in.  The argument is unused.

Here, we remove the function argument from the definition, and from the
single call site.  We then pass the filters to the initializer.

This makes it so that filters are in fact passed to the relay on the wire.