### PR TITLE
add PingRelays method to RelayPool

### DIFF
--- a/relaypool.go
+++ b/relaypool.go
@@ -277,3 +277,15 @@ func (r *RelayPool) PublishEvent(evt *Event) (*Event, chan PublishStatus, error)
 
 	return evt, status, nil
 }
+
+// PingRelays sends a PING to all relays in the pool
+func (rp *RelayPool) PingRelays() error {
+	for _, ws := range rp.websockets {
+		err := ws.WriteMessage(websocket.PingMessage, []byte("PING"))
+		if err != nil {
+			log.Printf("error sending ping: %s\n", err)
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
In order to keep relay sockets open indefinitely I added this PingRelays() method to the RelayPool struct. There may be better ways to structure this, perhaps a method that allows one to ping an individual relay by passing the normalized url as a key. If that is preferred, please let me know and I'm happy to make that version of this request.